### PR TITLE
fusesoc: Fix issue with vpi not building

### DIFF
--- a/jtag_vpi.core
+++ b/jtag_vpi.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : ::jtag_vpi:0-r3
+name : ::jtag_vpi:0-r4
 description : TCP/IP controlled VPI JTAG Interface
 
 filesets :
@@ -29,6 +29,7 @@ targets :
       - "tool_verilator? (verilator)"
       - "!tool_verilator? (vpi)"
     parameters: [jtag_vpi_enable]
+    vpi: [jtag_vpi]
 
 parameters:
   jtag_vpi_enable:


### PR DESCRIPTION
Without enabling the vpi module in the target it will not build for icarus and
cause failures.  This might not be the right fix as it will likely be
enabled for verilator too is that OK?

This fixes issue:

 https://github.com/fusesoc/fusesoc-cores/issues/6