### PR TITLE
Multiple fixes and improvements. Version incremented to jtag_vpi:0-r5.

### DIFF
--- a/jtagServer.h
+++ b/jtagServer.h
@@ -2,31 +2,20 @@
 #define __JTAG_SERVER_H__
 
 #include "jtag_common.h"
-#define XFERT_MAX_SIZE		512
-
-#define DONE			0
-#define IN_PROGRESS		1
-
-#define CMD_RESET		0
-#define CMD_TMS_SEQ		1
-#define CMD_SCAN_CHAIN		2
-#define CMD_SCAN_CHAIN_FLIP_TMS	3
-#define CMD_STOP_SIMU		4
-
-#define CHECK_CMD		0
-#define TAP_RESET		1
-#define GOTO_IDLE		2
-#define DO_TMS_SEQ		3
-#define SCAN_CHAIN		4
-#define FINISHED		5
 
 class VerilatorJtagServer {
 public:
+	enum {
+		SUCCESS,
+		ERROR,
+		CLIENT_DISCONNECTED
+	};
+
 	VerilatorJtagServer(uint64_t period);
 	~VerilatorJtagServer();
 
 	int doJTAG(uint64_t t, uint8_t *tms, uint8_t *tdi, uint8_t *tck, uint8_t tdo);
-	int init_jtag_server(int port);
+	int init_jtag_server(int port, bool loopback_only);
 
 private:
 	int gen_clk(uint64_t t, int nb_period, uint8_t *tck, uint8_t tdo, uint8_t *captured_tdo, int restart, int get_tdo);

--- a/jtag_common.c
+++ b/jtag_common.c
@@ -5,74 +5,273 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <stdlib.h>
+#include <netinet/tcp.h>
 
 #include "jtag_common.h"
 
-#define RSP_SERVER_PORT	5555
+// TODO: Networking on win32 not yet supported (winsock2.h et al.)
 
-int listenfd = 0;
-int connfd = 0;
+// Default TCP port where to listen for incoming OpenOCD connections
+#ifndef JTAG_VPI_DEFAULT_SERVER_PORT
+#define JTAG_VPI_DEFAULT_SERVER_PORT  5555
+#endif
 
-int init_jtag_server(int port)
+// Security: By default, do not listen on external interfaces (only on 127.0.0.1)
+#ifndef JTAG_VPI_IS_LOOPBACK_ONLY
+#define JTAG_VPI_IS_LOOPBACK_ONLY  1
+#endif
+
+// Socket descriptors
+static int listenfd = -1;  // Server socket (listening)
+static int connfd = -1;    // Connected client
+
+// Buffer for partially received packets
+char pkt_buf[ sizeof(struct jtag_cmd) ];
+unsigned pkt_buf_bytes = 0;
+
+// Function for printing of messages.
+// This is needed since the printing mechanism differs based on the simulator used.
+print_func_ptr_t print_function = NULL;
+
+// Macro to print a formatted message via the user-defined function
+#define PRINT_BUF_SIZE 256
+char print_buf[PRINT_BUF_SIZE];
+
+#define PRINT_MSG( ...) \
+	do { \
+		if (print_function) { \
+			snprintf( print_buf, PRINT_BUF_SIZE, __VA_ARGS__); \
+			print_buf[PRINT_BUF_SIZE - 1] = '\0'; \
+			print_function(print_buf); \
+		} \
+	} while (0)
+    
+
+static int is_host_little_endian(void);
+static uint32_t from_little_endian_u32(uint32_t val);
+static uint32_t to_little_endian_u32(uint32_t val);
+
+/**
+ * Set user-provided print function that will be used to display messages.
+ */
+void jtag_server_set_print_func( print_func_ptr_t f )
+{
+	print_function = f;
+}
+
+/**
+ * Create jtag_vpi server socket and start listening.
+ */
+int jtag_server_create(int port, int loopback_only)
 {
 	struct sockaddr_in serv_addr;
-	int flags;
+	int ret;
+	int fd;
 
-	printf("Listening on port %d\n", port);
+	PRINT_MSG("Starting jtag_vpi server: interface %s, port %d/tcp ...\n", 
+		loopback_only ? "127.0.0.1 (loopback)" : "0.0.0.0 (any)", port);
 
-	listenfd = socket(AF_INET, SOCK_STREAM, 0);
+	// Create server socket
+	fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (fd == -1) {
+		PRINT_MSG("Failed to create jtag_vpi server socket: errno=%d, %s\n", 
+			errno, strerror(errno));
+		return JTAG_SERVER_ERROR;
+	}
+	listenfd = fd;
+
+	// Bind the socket to a local port
 	memset(&serv_addr, '0', sizeof(serv_addr));
-
 	serv_addr.sin_family = AF_INET;
-	serv_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+	serv_addr.sin_addr.s_addr = htonl(loopback_only ? INADDR_LOOPBACK : INADDR_ANY);
 	serv_addr.sin_port = htons(port);
 
-	bind(listenfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+	ret = bind(listenfd, (struct sockaddr*)&serv_addr, sizeof(serv_addr));
+	if (ret == -1) {
+		PRINT_MSG("Failed to bind jtag_vpi server socket: errno=%d, %s\n", 
+			errno, strerror(errno));
+		return JTAG_SERVER_ERROR;
+	}
 
-	listen(listenfd, 10);
+	// Start listening for incoming connections
+	ret = listen(listenfd, 1);
+	if (ret == -1) {
+		PRINT_MSG("Could not start listening for jtag_vpi clients: errno=%d, %s\n", 
+			errno, strerror(errno));
+		return JTAG_SERVER_ERROR;
+	}
 
-	printf("Waiting for client connection...");
-	connfd = accept(listenfd, (struct sockaddr*)NULL, NULL);
-	printf("ok\n");
+	PRINT_MSG("jtag_vpi server created.\n");
+	PRINT_MSG("Waiting for client connection...\n");
 
-	flags = fcntl(listenfd, F_GETFL, 0);
-	fcntl(listenfd, F_SETFL, flags | O_NONBLOCK);
-
-	return 0;
+	return JTAG_SERVER_SUCCESS;
 }
 
-// See if there's anything on the FIFO for us
+/**
+ * Wait (block) until a jtag_vpi client (OpenOCD) connects.
+ */
+int jtag_server_wait_for_client(void)
+{
+	int fd;
+	int flags;
+	int ret;
 
-int check_for_command(struct jtag_cmd *vpi) {
+	// Accept a client (block)
+	fd = accept(listenfd, (struct sockaddr*)NULL, NULL);
+	if (fd == -1) {
+		// Error accepting the client
+		PRINT_MSG("Could not accept client connection: errno=%d, %s\n", 
+			errno, strerror(errno));
+		return JTAG_SERVER_ERROR;
+	}
+
+	connfd = fd;
+	PRINT_MSG("Client connection accepted.\n");
+
+	// Set the client socket to non-blocking mode
+	flags = fcntl(connfd, F_GETFL, 0);
+	ret = fcntl(connfd, F_SETFL, flags | O_NONBLOCK);
+	if (ret == -1) {
+		PRINT_MSG("Failed to set client socket to non-blocking mode: errno=%d, %s\n", 
+			errno, strerror(errno));
+		return JTAG_SERVER_ERROR;
+	}
+
+	// Set TCP_NODELAY for the client socket. This prevents delaying of outgoing data
+	// (Nagle's algorithm disabled) which improves the performance of jtag_vpi.
+	flags = 1;
+	ret = setsockopt(connfd, IPPROTO_TCP, TCP_NODELAY, (void *)&flags, sizeof(flags));
+	if (ret == -1) {
+		PRINT_MSG("Failed to set TCP_NODELAY: errno=%d, %s\n", 
+			errno, strerror(errno));
+		return JTAG_SERVER_ERROR;
+	}
+
+	return JTAG_SERVER_SUCCESS;
+}
+
+/**
+ * Check for an incoming jtag_vpi command from OpenOCD
+ * (non-blocking check).
+ */
+int check_for_command(struct jtag_cmd *packet)
+{
 	int nb;
-	// Get the command from TCP server
-	if(!connfd)
-	  init_jtag_server(RSP_SERVER_PORT);
-	nb = read(connfd, vpi, sizeof(struct jtag_cmd));
-	if (((nb < 0) && (errno == EAGAIN)) || (nb == 0)) {
-		// Nothing in the fifo this time, let's return
-		return 1;
-	} else {
-		if (nb < 0) {
-			// some sort of error
-			perror("check_for_command");
-			exit(1);
+	int ret;
+	if (connfd == -1) {
+		// jtag_vpi server does not run, so start it now
+		ret = jtag_server_create(JTAG_VPI_DEFAULT_SERVER_PORT, 
+			JTAG_VPI_IS_LOOPBACK_ONLY);
+		if (ret != JTAG_SERVER_SUCCESS) {
+			return ret;	
+		}
+		ret = jtag_server_wait_for_client();
+		if (ret != JTAG_SERVER_SUCCESS) {
+			return ret;
 		}
 	}
-	return 0;
+	// See if there is incoming data from OpenOCD
+	unsigned bytes_to_receive = sizeof(struct jtag_cmd) - pkt_buf_bytes;
+	nb = read(connfd, pkt_buf + pkt_buf_bytes, bytes_to_receive);
+	if (nb < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			// No data received at this time
+			return JTAG_SERVER_TRY_LATER;
+		}
+		else {
+			// An error when working with the socket
+			PRINT_MSG("Failed to receive data from OpenOCD: errno=%d, %s\n", 
+				errno, strerror(errno));
+			return JTAG_SERVER_ERROR;
+		}
+	}
+	else if (nb == 0) {
+		// Connection closed by the other side (OpenOCD disconnected)
+		PRINT_MSG("jtag_vpi client has disconnected.\n");
+
+		// Close at our end as well.
+		jtag_server_finish();
+
+		return JTAG_SERVER_CLIENT_DISCONNECTED;
+	}
+	else {
+		// Some data arrived (nb > 0)
+		pkt_buf_bytes += nb;
+		if (pkt_buf_bytes < sizeof(struct jtag_cmd)) {
+			// Not yet a whole packet, wait for the rest
+			return JTAG_SERVER_TRY_LATER;
+		}
+
+		// We have a full jtag_vpi packet
+		pkt_buf_bytes = 0;
+		memcpy(packet, pkt_buf, sizeof(struct jtag_cmd));
+
+		// Handle endianness of received data
+		packet->cmd = from_little_endian_u32(packet->cmd);
+		packet->length = from_little_endian_u32(packet->length);
+		packet->nb_bits = from_little_endian_u32(packet->nb_bits);
+
+		return JTAG_SERVER_SUCCESS;
+	}
 }
 
-int send_result_to_server(struct jtag_cmd *vpi) {
+/**
+ * Send response packet back to OpenOCD.
+ */
+int send_result_to_server(struct jtag_cmd *packet)
+{
 	ssize_t n;
-	n = write(connfd, vpi, sizeof(struct jtag_cmd));
-	if (n < (ssize_t)sizeof(struct jtag_cmd))
-	  return -1;
-	return 0;
+
+	// Handle endianness of the data being sent
+	packet->cmd = to_little_endian_u32(packet->cmd);
+	packet->length = to_little_endian_u32(packet->length);
+	packet->nb_bits = to_little_endian_u32(packet->nb_bits);
+
+	// Send the packet to OpenOCD
+	n = write(connfd, packet, sizeof(struct jtag_cmd));
+	if (n < (ssize_t)sizeof(struct jtag_cmd)) {
+		// Failed to write to socket. Cannot recover from this.
+		PRINT_MSG("Failed to send data to OpenOCD: errno=%d, %s\n", errno, strerror(errno));
+		return JTAG_SERVER_ERROR;
+	}
+	return JTAG_SERVER_SUCCESS;
 }
 
-void jtag_finish(void) {
-  	if(connfd)
-		printf("Closing RSP server\n");
-	close(connfd);
-	close(listenfd);
+/**
+ * Close server sockets
+ */
+void jtag_server_finish(void)
+{
+	if (connfd != -1) {
+		close(connfd);
+		connfd = -1;
+	}
+	if (listenfd != -1) {
+		close(listenfd);
+		listenfd = -1;
+	}
+}
+
+/**
+ * Helper function. Determine if this machine is little endian.
+ */
+static int is_host_little_endian(void)
+{
+	return (htonl(25) != 25);
+}
+
+/**
+ * Helper function. Convert u32 from little endian to host endianness.
+ */
+static uint32_t from_little_endian_u32(uint32_t val)
+{
+	return is_host_little_endian() ? val : htonl(val);
+}
+
+/**
+ * Helper function. Convert u32 from host endianness to little endian.
+ */
+static uint32_t to_little_endian_u32(uint32_t val)
+{
+	return from_little_endian_u32(val);
 }

--- a/jtag_common.h
+++ b/jtag_common.h
@@ -1,8 +1,14 @@
 #ifndef __JTAG_COMMON_H__
 #define __JTAG_COMMON_H__
 
+#define JTAG_SERVER_SUCCESS  0
+#define JTAG_SERVER_ERROR  1
+#define JTAG_SERVER_TRY_LATER  2
+#define JTAG_SERVER_CLIENT_DISCONNECTED  3
+
 #define	XFERT_MAX_SIZE	512
 
+// jtag_vpi packet structure
 struct jtag_cmd {
 	uint32_t cmd;
 	unsigned char buffer_out[XFERT_MAX_SIZE];
@@ -11,9 +17,13 @@ struct jtag_cmd {
 	uint32_t nb_bits;
 };
 
-int init_jtag_server(int port);
+typedef void (*print_func_ptr_t)(char *);
+
+void jtag_server_set_print_func(print_func_ptr_t f);
+int jtag_server_create(int port, int loopback_only);
+int jtag_server_wait_for_client(void);
 int check_for_command(struct jtag_cmd *vpi);
 int send_result_to_server(struct jtag_cmd *vpi);
-void jtag_finish(void);
+void jtag_server_finish(void);
 
 #endif

--- a/jtag_vpi.core
+++ b/jtag_vpi.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : ::jtag_vpi:0-r4
+name : ::jtag_vpi:0-r5
 description : TCP/IP controlled VPI JTAG Interface
 
 filesets :


### PR DESCRIPTION
- Fix: Non-blocking reading from jtag_vpi socket
- Fix: Reception of incomplete jtag_vpi packet is tolerated (partial packets are buffered).
- Fix: All socket operations are checked for errors. Error messages are provided to the user.
- Fix: Proper termination of simulation when client disconnects or on error. Added return codes to DoJTAG().
- Fix: Termination of VPI-based simulators using vpi_control()
- Fix: Endianness of jtag_vpi messages handled also for Verilator JTAG server (not only for jtag_vpi.c)
- Security: By default, listen only on local interface (127.0.0.1), not on all interfaces
- TCP_NODELAY utilized to decrease jtag_vpi latency
- init_jtag_server() split to jtag_server_create() and jtag_server_wait_for_client() for clarity
- Printing of messages handled for both Verilator and VPI-based simulators (printf() vs. vpi_printf())
- Minor code cleanup (comments, naming, etc.)