### PR TITLE
Add support Verilator 5.X

### DIFF
--- a/sim/bin/Makefile.verilator
+++ b/sim/bin/Makefile.verilator
@@ -5,7 +5,13 @@ VERILOG_ROOT := ../../bench/verilog
 VERILOG_FILES := $(VERILOG_ROOT)/jtag_soc.v $(VERILOG_ROOT)/jtag_tap/jtag_tap.v  $(VERILOG_ROOT)/adv_debugsys/*.v $(VERILOG_ROOT)/ram/ram_wb_b3.v
 VERILOG_INCLUDES := $(VERILOG_ROOT)/include 
 
-VFLAGS := --trace -cc -Wno-UNOPTFLAT -Wno-COMBDLY  -Wno-WIDTH  -Wno-BLKSEQ -Wno-UNUSED -Wno-CASEINCOMPLETE -Wno-PINMISSING   -Wno-PINCONNECTEMPTY -Wno-ASSIGNDLY
+VFLAGS := --exe --trace -cc -Wno-UNOPTFLAT -Wno-COMBDLY  -Wno-WIDTH  -Wno-BLKSEQ -Wno-UNUSED -Wno-CASEINCOMPLETE -Wno-PINMISSING   -Wno-PINCONNECTEMPTY -Wno-ASSIGNDLY
+
+export verilator_ver_5x ?= $(shell  expr `verilator --version | cut -f2 -d' '` \>= 5)
+
+ifeq "$(verilator_ver_5x)" "1"
+    VFLAGS += --no-timing
+endif
 
 SUBMAKE := $(MAKE) --no-print-directory -C
 
@@ -17,24 +23,18 @@ VINCD   := $(VROOT)/include
 VSRCRAW := verilated.cpp verilated_vcd_c.cpp
 VSRC    := $(addprefix $(VINCD)/,$(VSRCRAW))
 
-verilator: library verilate
-
-library:
-	$(VERILATOR) $(VFLAGS) -I$(VERILOG_INCLUDES) $(VERILOG_FILES)
+verilator:
+	$(VERILATOR) $(VFLAGS) -I$(VERILOG_INCLUDES) $(VERILOG_FILES) ../../bench/verilator/tb.cpp ../../jtag_common.c ../../jtagServer.cpp $(VSRC)
 	$(SUBMAKE) $(VDIRFB)/ -f Vjtag_soc.mk
-
-verilate:
-	$(CXX) -I$(VDIRFB) -I$(VINCD) -I$(VINCD)/vltstd ../../bench/verilator/tb.cpp ../../jtag_common.c ../../jtagServer.cpp $(VSRC) $(VDIRFB)/Vjtag_soc__ALL.a -o tb
 
 sim: verilator
 	$(Q)gcc -o test_client ../../bench/test_client.c
 	@echo '##### Start the simulation ######'
-	$(Q)./tb &
+	$(Q)./obj_dir/Vjtag_soc &
 	@sleep 1
 	@echo '##### Running the test client ######'
 	$(Q)./test_client
 	@sleep 1
 clean:
 	@rm -rf obj_dir
-	@rm -f ./tb
 	@rm -f ./sim.vcd


### PR DESCRIPTION
Verilator 5 and upper added options `--timing/--no-timing` (https://verilator.org/guide/latest/changes.html#verilator-5-002-2022-10-29). Without this option project does not verilated with an error `%Error-NEEDTIMINGOPT`.
And change rule `verilator` in file `Makefile.verilator` because Verilator 5 and upper failed in link stage (`undefined reference «VlThreadPool::VlThreadPool(VerilatedContext*, unsigned int)»`).  